### PR TITLE
Дать возможность склонять элементы ФИО без инстанциирования класса Petrovich

### DIFF
--- a/src/NPetrovich.Tests/Fixtures/CaseInflectionFixtureStandalone.cs
+++ b/src/NPetrovich.Tests/Fixtures/CaseInflectionFixtureStandalone.cs
@@ -1,0 +1,40 @@
+﻿using NPetrovich.Inflection;
+using NPetrovich.Rules;
+using NPetrovich.Rules.Loader;
+using NPetrovich.Tests.TestDataProviders;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.IO;
+using System.Linq;
+
+namespace NPetrovich.Tests.Fixtures
+{
+    [TestFixture]
+    public class CaseInflectionFixtureStandalone
+    {
+        [Test]
+        [TestCaseSource(typeof(InflectionTestCaseDataFactory), "FirstNamesInflectionData")]
+        public void Should_inflect_first_name_correctly(string firstName, Gender gender, Case @case, string expected)
+        {
+            var actual = new CaseInflection(gender).InflectFirstNameTo(firstName, @case);
+            Assert.AreEqual(expected, actual, string.Format("Gender: {0}, Case: {1}", gender, @case));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(InflectionTestCaseDataFactory), "LastNamesInflectionData")]
+        public void Should_inflect_last_name_correctly(string lastName, Gender gender, Case @case, string expected)
+        {
+            var actual = new CaseInflection(gender).InflectLastNameTo(lastName, @case);
+            Assert.AreEqual(expected, actual, string.Format("Gender: {0}, Case: {1}", gender, @case));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(InflectionTestCaseDataFactory), "MiddleNamesInflectionData")]
+        public void Should_inflect_middle_name_correctly(string middleName, Gender gender, Case @case, string expected)
+        {
+            var actual = new CaseInflection(gender).InflectMiddleNameTo(middleName, @case);
+            Assert.AreEqual(expected, actual, string.Format("Gender: {0}, Case: {1}", gender, @case));
+        }
+    }
+}

--- a/src/NPetrovich.Tests/NPetrovich.Tests.csproj
+++ b/src/NPetrovich.Tests/NPetrovich.Tests.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Fixtures\CaseInflectionFixtureStandalone.cs" />
     <Compile Include="Fixtures\PetrovichFixture.cs" />
     <Compile Include="Fixtures\RulesFixture.cs" />
     <Compile Include="Fixtures\RulesProviderFixture.cs" />

--- a/src/NPetrovich/Case.cs
+++ b/src/NPetrovich/Case.cs
@@ -2,11 +2,34 @@
 {
     public enum Case
     {
+        /// <summary>
+        /// именительный
+        /// </summary>
         Nominative,
+
+        /// <summary>
+        ///родительный
+        /// </summary>
         Genitive,
+
+        /// <summary>
+        /// дательный
+        /// </summary>
         Dative,
+
+        /// <summary>
+        ///винительный
+        /// </summary>
         Accusative,
+
+        /// <summary>
+        ///творительный
+        /// </summary>
         Instrumental,
+
+        /// <summary>
+        ///предложный
+        /// </summary>
         Prepositional
     }
 }

--- a/src/NPetrovich/Inflection/CaseInflection.cs
+++ b/src/NPetrovich/Inflection/CaseInflection.cs
@@ -3,15 +3,22 @@ using System.Collections.Generic;
 using System.Linq;
 using NPetrovich.Rules;
 using NPetrovich.Rules.Data;
+using NPetrovich.Rules.Loader;
 
 namespace NPetrovich.Inflection
 {
-    internal class CaseInflection
+    public class CaseInflection
     {
         private readonly RulesProvider provider;
         private readonly Gender gender;
 
-        public CaseInflection(RulesProvider provider, Gender gender)
+        public CaseInflection(Gender gender, IRulesLoader rulesLoader = null)
+            : this(new RulesProvider((rulesLoader ?? new EmbeddedResourceLoader())), gender)
+        {
+
+        }
+
+        internal CaseInflection(RulesProvider provider, Gender gender)
         {
             this.provider = provider;
             this.gender = gender;


### PR DESCRIPTION
В своей практике столкнулся с задачей просклонять большой набор частей ФИО по-отдельности.

Оказалось, что текущий интерфейс Петровича довольно плохо приспособлен к такому использованию. Если надо просклонять, скажем, отдельно имя "Иван", то надо создать инстанс класса `Petrovich`, заполнить поля, вызвать метод `InflectFirstNameTo`, который еще полезет определять пол, потом еще результат сохранится в инстансе класса, поэтому когда я захочу просклонять это же имя к другому падежу, то нужно будет заново заполнять поля класса... 
Все это выглядит слишком громоздко и неочевидно.

При этом в коде уже есть вполне подходящий класс — CaseInflection, который делает ровно то, что мне нужно. Мне кажется вполне разумно сделать его публичным.