### PR TITLE
Support rules in JSON format

### DIFF
--- a/src/NPetrovich/NPetrovich.csproj
+++ b/src/NPetrovich/NPetrovich.csproj
@@ -34,6 +34,10 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -41,11 +45,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="YamlDotNet.Core">
-      <HintPath>..\packages\YamlDotNet.Core.2.2.0\lib\net35\YamlDotNet.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="YamlDotNet.RepresentationModel">
-      <HintPath>..\packages\YamlDotNet.RepresentationModel.2.2.0\lib\net35\YamlDotNet.RepresentationModel.dll</HintPath>
+    <Reference Include="YamlDotNet, Version=3.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.3.9.0\lib\net35\YamlDotNet.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -62,6 +64,7 @@
     <Compile Include="Rules\Data\Rules.cs" />
     <Compile Include="Rules\Data\RuleSet.cs" />
     <Compile Include="Rules\Parser\IRulesParser.cs" />
+    <Compile Include="Rules\Parser\Json\JsonRulesParser.cs" />
     <Compile Include="Rules\Parser\Yaml\YamlRulesParser.cs" />
     <Compile Include="Rules\RulesProvider.cs" />
     <Compile Include="Utils\GenderUtils.cs">
@@ -72,8 +75,13 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <EmbeddedResource Include="..\rules\rules.json">
+      <Link>rules.json</Link>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\rules\rules.yml" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/NPetrovich/Rules/Data/Rule.cs
+++ b/src/NPetrovich/Rules/Data/Rule.cs
@@ -1,20 +1,25 @@
 ﻿using System.Collections.Generic;
-using YamlDotNet.RepresentationModel.Serialization;
+using Newtonsoft.Json;
+using YamlDotNet.Serialization;
 
 namespace NPetrovich.Rules.Data
 {
     public class Rule
     {
-        [YamlAlias("gender")]
+        [YamlMember(Alias = "gender")]
+        [JsonProperty(PropertyName = "gender")]
         public string Gender { get; set; }
 
-        [YamlAlias("test")]
+        [YamlMember(Alias = "test")]
+        [JsonProperty(PropertyName = "test")]
         public List<string> TestSuffixes { get; set; }
 
-        [YamlAlias("mods")]
+        [YamlMember(Alias = "mods")]
+        [JsonProperty(PropertyName = "mods")]
         public List<string> ModSuffixes { get; set; }
 
-        [YamlAlias("tags")]
+        [YamlMember(Alias = "tags")]
+        [JsonProperty(PropertyName = "tags")]
         public List<string> Tags { get; set; }
     }
 }

--- a/src/NPetrovich/Rules/Data/RuleSet.cs
+++ b/src/NPetrovich/Rules/Data/RuleSet.cs
@@ -1,14 +1,17 @@
 ﻿using System.Collections.Generic;
-using YamlDotNet.RepresentationModel.Serialization;
+using Newtonsoft.Json;
+using YamlDotNet.Serialization;
 
 namespace NPetrovich.Rules.Data
 {
     public class RuleSet
     {
-        [YamlAlias("exceptions")]
+        [YamlMember(Alias = "exceptions")]
+        [JsonProperty(PropertyName = "exceptions")]
         public List<Rule> Exceptions { get; set; }
 
-        [YamlAlias("suffixes")]
+        [YamlMember(Alias = "suffixes")]
+        [JsonProperty(PropertyName = "suffixes")]
         public List<Rule> Suffixes { get; set; }
     }
 }

--- a/src/NPetrovich/Rules/Data/Rules.cs
+++ b/src/NPetrovich/Rules/Data/Rules.cs
@@ -1,16 +1,20 @@
-﻿using YamlDotNet.RepresentationModel.Serialization;
+﻿using Newtonsoft.Json;
+using YamlDotNet.Serialization;
 
 namespace NPetrovich.Rules.Data
 {
     public class Rules
     {
-        [YamlAlias("lastname")]
+        [YamlMember(Alias = "lastname")]
+        [JsonProperty(PropertyName = "lastname")]
         public RuleSet LastName { get; set; }
 
-        [YamlAlias("firstname")]
+        [YamlMember(Alias = "firstname")]
+        [JsonProperty(PropertyName = "firstname")]
         public RuleSet FirstName { get; set; }
 
-        [YamlAlias("middlename")]
+        [YamlMember(Alias = "middlename")]
+        [JsonProperty(PropertyName = "middlename")]
         public RuleSet MiddleName { get; set; }
     }
 }

--- a/src/NPetrovich/Rules/Loader/EmbeddedResourceLoader.cs
+++ b/src/NPetrovich/Rules/Loader/EmbeddedResourceLoader.cs
@@ -1,20 +1,43 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using NPetrovich.Rules.Parser;
+using NPetrovich.Rules.Parser.Json;
 using NPetrovich.Rules.Parser.Yaml;
 
 namespace NPetrovich.Rules.Loader
 {
     public class EmbeddedResourceLoader : IRulesLoader
     {
+        public Data.Rules LoadYaml()
+        {
+            return Load("NPetrovich.rules.yml", new YamlRulesParser());
+        }
+
+        public Data.Rules LoadJson()
+        {
+            return Load("NPetrovich.rules.json", new JsonRulesParser());
+        }
+
         public Data.Rules Load()
         {
+            return LoadYaml();
+        }
+
+        public Data.Rules Load(string resourceName, IRulesParser parser)
+        {
             var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = "NPetrovich.rules.yml";
 
             using (var stream = assembly.GetManifestResourceStream(resourceName))
-            using (var reader = new StreamReader(stream))
-                return new YamlRulesParser().Parse(reader);
+            {
+                if (stream == null)
+                    throw new IOException(String.Format("Couldn't load embedded resource \"{0}\"", resourceName));
+
+                using (var reader = new StreamReader(stream))
+                {
+                    return parser.Parse(reader);
+                }
+            }
         }
     }
 }

--- a/src/NPetrovich/Rules/Parser/Json/JsonRulesParser.cs
+++ b/src/NPetrovich/Rules/Parser/Json/JsonRulesParser.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace NPetrovich.Rules.Parser.Json
+{
+    public class JsonRulesParser : IRulesParser
+    {
+        public Data.Rules Parse(StreamReader data)
+        {
+            string json = data.ReadToEnd();
+            return JsonConvert.DeserializeObject<Data.Rules>(json);
+        }
+    }
+}

--- a/src/NPetrovich/Rules/Parser/Yaml/YamlRulesParser.cs
+++ b/src/NPetrovich/Rules/Parser/Yaml/YamlRulesParser.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using YamlDotNet.RepresentationModel.Serialization;
+using YamlDotNet.Serialization;
 
 namespace NPetrovich.Rules.Parser.Yaml
 {

--- a/src/NPetrovich/packages.config
+++ b/src/NPetrovich/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="YamlDotNet.Core" version="2.2.0" targetFramework="net45" />
-  <package id="YamlDotNet.RepresentationModel" version="2.2.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40-client" />
+  <package id="YamlDotNet" version="3.9.0" targetFramework="net40-client" />
 </packages>


### PR DESCRIPTION
**Add support for rules in JSON format:**
- Add rules.json as embedded resource.
- Add JsonRulesParser class (depends on Newtonsoft.Json nuget package).
- Add JSON parsing attributes to Rules/Data classes.
- Change EmbeddedResourceLoader class to allow both Yaml and JSON resource file. Good idea to create app.config to manage which file to use as a default embedded resource, but there are no app.config in the project and I think there is a reason for it so I didn't create it.

**Update Yaml library:**
- Old yaml libraries are marked as deprecated in Nuget package manager. So I replace it with new one.
- Change Yaml-attributes at Rules/Data classes for new library.
